### PR TITLE
Add chamber "tags" where appropriate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ Homestead.yaml
 /public/css/*
 /public/js/*
 /public/mix-manifest.json
+.vscode/settings.json

--- a/resources/assets/js/components/bill-table.vue
+++ b/resources/assets/js/components/bill-table.vue
@@ -18,7 +18,7 @@
                 </td>
                 <td class="bill-table__bill-actions">
                     <div v-if="bill.actions[0]">
-                        <div class="bill-table__action-type">{{bill.actions[0].ActionType}}</div>
+                        <div class="bill-table__action-type">({{bill.actions[0].Chamber.substr(0,1)}}) {{bill.actions[0].ActionType}}</div>
                         <div class="bill-table__action-details">
                             {{bill.actions[0].Description}}<br>
                             {{formatDate(bill.actions[0].Date)}}
@@ -28,7 +28,7 @@
                 </td>
                 <td class="bill-table__bill-actions">
                     <div v-if="bill.scheduled_actions[0]">
-                        <div class="bill-table__action-type">{{bill.scheduled_actions[0].ActionType}}</div>
+                        <div class="bill-table__action-type">({{bill.scheduled_actions[0].Chamber.substr(0,1)}}) {{bill.scheduled_actions[0].ActionType}}</div>
                         <div class="bill-table__action-details">{{formatDate(bill.scheduled_actions[0].Date)}}<br>
                             <div v-if="bill.scheduled_actions[0].Start">
                                 {{formatTime(bill.scheduled_actions[0].Start)}} - {{formatTime(bill.scheduled_actions[0].End)}}<br>

--- a/resources/assets/js/components/bill.vue
+++ b/resources/assets/js/components/bill.vue
@@ -7,7 +7,7 @@
 
                 <div class="bill__tags" v-if="b.committees.length">Committee:
                     <span class="bill__tag" v-for="(committee, index) in b.committees">
-                                {{committee.Name}}<span v-if="index!=b.committees.length-1">,&nbsp;</span>
+                                ({{committee.Chamber.substr(0,1)}}) {{committee.Name}}<span v-if="index!=b.committees.length-1">,&nbsp;</span>
                             </span>
                 </div>
                 <div class="bill__tags" v-if="b.subjects.length">Subject:


### PR DESCRIPTION
Since bills have to pass through both chambers on their way to becoming law, it'd be helpful to disambiguate chambers to which bills are assigned and in which events occur. This can be done pretty effectively with just an `(H)` or `(S)` tag in the appropriate place. The IGA website does something similar on their bill actions lists.

Changes:

1. On the All Bills view, add a tag to the committee names: 

`Committee: Ways and Means` thus becomes `Committee: (H) Ways and Means`

2. On the My Bills view, add a tag to the action type: 

| Most Recent Event | Next Scheduled Event |
| ---------------------| -------------------------|
| Committee Reading | Second Reading          |

thus becomes

| Most Recent Event | Next Scheduled Event |
| ---------------------| -------------------------|
| (H) Committee Reading | (H) Second Reading |

